### PR TITLE
Update embeds.sp

### DIFF
--- a/discord_redux/embeds.sp
+++ b/discord_redux/embeds.sp
@@ -89,7 +89,7 @@ public void Embed_CurrentMapStatus()
         embed.AddField(playerCountField, playerField, true);
 
     // Map Rate Average
-    if (g_ConVars[map_rating_enabled].BoolValue && g_HasMapEnded)
+    if (g_IsMapRateLoaded && g_ConVars[map_rating_enabled].BoolValue && g_HasMapEnded)
     {
         char ratingValue[16];
         int stars = RoundFloat(MapRate_GetAverage(mapName));        


### PR DESCRIPTION
The current implementation only adds the `map_rating_enabled` convar if `g_IsMapRateLoaded` is true, this adds a check for `g_IsMapRateLoaded` in `embeds.sp` to fix it not posting without Map Rate installed.